### PR TITLE
Myles routes cleanup

### DIFF
--- a/routes/apiRoutes/event-routes.js
+++ b/routes/apiRoutes/event-routes.js
@@ -1,11 +1,16 @@
-const router = require('express').Router();
-const eventController = require('../controllers/eventController');
+const controller = require('../controllers/eventController');
+const routerSetupHelper = require('../../utils/routerHelper');
 
-router.get('/', eventController.getAll);
-router.post('/', eventController.create);
-router.get('/:id', eventController.getOne);
-router.put('/:id', eventController.update);
-router.delete('/:id', eventController.delete);
-router.get('/test/:id', eventController.testFind)
+const config = [
+  {http: 'get', path: '/', method: 'getAll'},
+  {http: 'post', path: '/', method: 'create'},
+  {http: 'get', path: '/:id', method: 'getOne'},
+  {http: 'put', path: '/:id', method: 'update'},
+  {http: 'delete', path: '/:id', method: 'delete'}
+]
+
+const router = routerSetupHelper(config, controller);
+
+router.get('/test/:id', controller.testFind)
 
 module.exports = router;

--- a/routes/controllers/eventController.js
+++ b/routes/controllers/eventController.js
@@ -11,24 +11,6 @@ exports.getAll = function (req, res) {
   })
 };
 
-exports.renderAll = function (req, res) {
-  Event.findAll({
-    include: {
-      model: Owner,
-      as: 'host',
-      include: Dog
-    },
-    raw: true
-  })
-  .then((events) => {
-    res.status(200).render('events', {events, logged_in: req.session.logged_in});
-  })
-  .catch((err) => {
-    console.log(err);
-    res.status(400).json(err);
-  });
-};
-
 exports.getOne = function (req, res) {
   // find one event by their `id` value (primary key)
   // include their dogs

--- a/routes/controllers/eventController.js
+++ b/routes/controllers/eventController.js
@@ -35,8 +35,7 @@ exports.create = function (req, res) {
   let data = req.body;
   data.host_id = req.body.owner_id || req.session.user_id; 
   if (!data.host_id) {
-    res.status(400).json({message: 'No user_id included in req.body or req.session'});
-    return;
+    return Promise.reject('No user_id included in req.body or req.session');
   }
   return Event.create(data)
 };

--- a/routes/controllers/eventController.js
+++ b/routes/controllers/eventController.js
@@ -2,20 +2,13 @@ const { Event, Owner, Dog, Comment } = require('../../models');
 
 exports.getAll = function (req, res) {
   // find all events, include their dogs
-  Event.findAll({
+  return Event.findAll({
     include: {
       model: Owner,
       as: 'host',
       include: Dog
     }
   })
-  .then((events) => {
-    res.status(200).json(events);
-  })
-  .catch((err) => {
-    console.log(err);
-    res.status(400).json(err);
-  });
 };
 
 exports.renderAll = function (req, res) {
@@ -39,7 +32,7 @@ exports.renderAll = function (req, res) {
 exports.getOne = function (req, res) {
   // find one event by their `id` value (primary key)
   // include their dogs
-  Event.findOne({
+  return Event.findOne({
     where: {id: req.params.id},
     include: [{
       model: Owner,
@@ -53,13 +46,6 @@ exports.getOne = function (req, res) {
       model: Comment
     }]
   })
-  .then((event) => {
-    res.status(200).json(event);
-  })
-  .catch((err) => {
-    console.log(err);
-    res.status(400).json(err);
-  });
 };
 
 exports.create = function (req, res) {
@@ -70,46 +56,25 @@ exports.create = function (req, res) {
     res.status(400).json({message: 'No user_id included in req.body or req.session'});
     return;
   }
-  Event.create(data)
-  .then((event) => {
-    res.status(200).json(event);
-  })
-  .catch((err) => {
-    console.log(err);
-    res.status(400).json(err);
-  });
+  return Event.create(data)
 };
 
 exports.update = function (req, res) {
   // update a event by its `id` value
-  Event.update(req.body, {
+  return Event.update(req.body, {
     where: {
       id: req.params.id
     }
   })
-  .then((event) => {
-    res.status(200).json(event);
-  })
-  .catch((err) => {
-    console.log(err);
-    res.status(400).json(err);
-  });
 };
 
 exports.delete = function (req, res) {
   // delete a event by its `id` value
-  Event.destroy({
+  return Event.destroy({
     where: {
       id: req.params.id
     }
   })
-  .then((event) => {
-    res.status(200).json(event);
-  })
-  .catch((err) => {
-    console.log(err);
-    res.status(400).json(err);
-  });
 };
 
 exports.testFind = function (req, res) {

--- a/routes/homeRoutes.js
+++ b/routes/homeRoutes.js
@@ -25,6 +25,16 @@ router.get('/signup', (req, res) => {
     });
 });
 
-router.get('/events', eventController.renderAll);
+router.get('/events', (req, res) => {
+    eventController.getAll(req, res)
+    .then(events => {
+        plainEvents = events.get({plain: true});
+        res.status(200).render('events', {plainEvents, logged_in: req.session.logged_in});
+    })
+    .catch(err => {
+        res.redirect('/');
+        console.log(err);
+    })
+});
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,14 +1,9 @@
-// Create the /api route
 const router = require('express').Router();
 
 const apiRoutes = require('./apiRoutes');
-const homeRoutes = require('./homeRoutes');
-const profileRoutes = require('./profileRoutes');
-// const eventRoutes = require('./eventRoutes');
+const viewRoutes = require('./viewRoutes');
 
 router.use('/api', apiRoutes);
-router.use('/', homeRoutes);
-router.use('/profile', profileRoutes);
-// router.use('/events', eventRoutes);
+router.use('/', viewRoutes);
 
 module.exports = router;

--- a/routes/viewRoutes/eventRoutes.js
+++ b/routes/viewRoutes/eventRoutes.js
@@ -4,10 +4,20 @@ const eventController = require('../controllers/eventController');
 router.get('/', (req, res) => {
   eventController.getAll(req, res)
   .then(events => {
-    plainEvents = events.map(event => event.get({ plain: true }))
-    console.log(plainEvents)
-    console.log(req.session)
+    plainEvents = events.map(event => event.get({ plain: true }));
     res.status(200).render('events', {events: plainEvents, logged_in: req.session.logged_in});
+  })
+  .catch(err => {
+      res.redirect('../');
+      console.log(err);
+  })
+});
+
+router.get('/:id', (req, res) => {
+  eventController.getOne(req, res)
+  .then(event => {
+    plainEvent = event.get({ plain: true });
+    res.status(200).render('eventsprofile', {...event, logged_in: req.session.logged_in});
   })
   .catch(err => {
       res.redirect('../');

--- a/routes/viewRoutes/eventRoutes.js
+++ b/routes/viewRoutes/eventRoutes.js
@@ -17,7 +17,7 @@ router.get('/:id', (req, res) => {
   eventController.getOne(req, res)
   .then(event => {
     plainEvent = event.get({ plain: true });
-    res.status(200).render('eventsprofile', {...event, logged_in: req.session.logged_in});
+    res.status(200).render('eventprofile', {...event, logged_in: req.session.logged_in});
   })
   .catch(err => {
       res.redirect('../');

--- a/routes/viewRoutes/eventRoutes.js
+++ b/routes/viewRoutes/eventRoutes.js
@@ -1,0 +1,18 @@
+const router = require('express').Router();
+const eventController = require('../controllers/eventController');
+
+router.get('/', (req, res) => {
+  eventController.getAll(req, res)
+  .then(events => {
+    plainEvents = events.map(event => event.get({ plain: true }))
+    console.log(plainEvents)
+    console.log(req.session)
+    res.status(200).render('events', {events: plainEvents, logged_in: req.session.logged_in});
+  })
+  .catch(err => {
+      res.redirect('../');
+      console.log(err);
+  })
+});
+
+module.exports = router

--- a/routes/viewRoutes/homeRoutes.js
+++ b/routes/viewRoutes/homeRoutes.js
@@ -1,6 +1,5 @@
 const router = require('express').Router();
-const { Owner, Dog, Event } = require('../models');
-const eventController = require('./controllers/eventController');
+const eventController = require('../controllers/eventController');
 
 router.get('/', async (req, res) => {
     res.render('homepage', {
@@ -23,18 +22,6 @@ router.get('/signup', (req, res) => {
     res.render('signup', {
         logged_in: req.session.logged_in
     });
-});
-
-router.get('/events', (req, res) => {
-    eventController.getAll(req, res)
-    .then(events => {
-        plainEvents = events.get({plain: true});
-        res.status(200).render('events', {plainEvents, logged_in: req.session.logged_in});
-    })
-    .catch(err => {
-        res.redirect('/');
-        console.log(err);
-    })
 });
 
 module.exports = router;

--- a/routes/viewRoutes/index.js
+++ b/routes/viewRoutes/index.js
@@ -1,0 +1,11 @@
+// Create the different routes under the [root domain]/ route
+const router = require('express').Router();
+const homeRoutes = require('./homeRoutes');
+const profileRoutes = require('./profileRoutes');
+const eventRoutes = require('./eventRoutes');
+
+router.use('/', homeRoutes);
+router.use('/profile', profileRoutes);
+router.use('/events', eventRoutes);
+
+module.exports = router;

--- a/routes/viewRoutes/profileRoutes.js
+++ b/routes/viewRoutes/profileRoutes.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
-const { Owner, Dog, Event, Comment } = require('../models');
-const withAuth = require('../utils/auth');
+const { Owner, Dog, Event, Comment } = require('../../models');
+const withAuth = require('../../utils/auth');
 
 //Gets ALL posts and displays it on homepage
 router.get('/', withAuth, async (req, res) => {

--- a/utils/routerHelper.js
+++ b/utils/routerHelper.js
@@ -9,6 +9,8 @@ const routerSetupHelper = (routeConfig, controller) => {
   return router;
 }
 
+// Note: method passed from controller MUST return a promise
+// Use promise.resolve or .reject to send static data
 function routeHelper(req, res, method, controller) {
   return controller[method](req, res)
   .then(item => res.status(200).json(item))

--- a/utils/routerHelper.js
+++ b/utils/routerHelper.js
@@ -1,0 +1,18 @@
+const router = require('express').Router();
+
+const routerSetupHelper = (routeConfig, controller) => {
+  routeConfig.forEach(route => {
+    router[route.http](route.path, (req, res) => {
+      routeHelper(req, res, route.method, controller)
+    })
+  })
+  return router;
+}
+
+function routeHelper(req, res, method, controller) {
+  return controller[method](req, res)
+  .then(item => res.status(200).json(item))
+  .catch(err => res.status(400).json(err))
+}
+
+module.exports = routerSetupHelper;


### PR DESCRIPTION
Further modularization and separation of routing concerns and model controller logic.

Route setup helper util added that takes a config array of objects with {http method, path, controller method} and automatically calls router.httpMethod for each route.

Controller routes now need to return a promise. Note: sequelize methods like Event.findAll are already promises and can be returned and used directly as is.

For advanced pre/post processing around the sequelize calls, a wrapper needs to be used like new Promise( ... => { method body including resolve/reject conditions })