### PR TITLE
Myles event views

### DIFF
--- a/routes/controllers/eventController.js
+++ b/routes/controllers/eventController.js
@@ -31,21 +31,24 @@ exports.getAllforUser = function (req, res) {
 
 exports.getOne = function (req, res) {
   // find one event by their `id` value (primary key)
-  // include their dogs
   return Event.findOne({
     where: {id: req.params.id},
     include: [{
       model: Owner,
       as: 'host',
-      include: Dog
+      attributes: ['first_name', 'last_name', 'pic_hyperlink'],
+      include: { model: Dog }
     }, 
     {
       model: Owner,
-      as: 'attendees'
+      as: 'attendees',
+      attributes: ['first_name','last_name', 'pic_hyperlink']
     }, {
-      model: Comment
+      model: Comment,
+      attributes: ['text'],
+      include: { model: Owner, attributes: ['first_name'] }
     }]
-  })
+  });
 };
 
 exports.create = function (req, res) {

--- a/routes/viewRoutes/eventRoutes.js
+++ b/routes/viewRoutes/eventRoutes.js
@@ -7,7 +7,10 @@ router.get('/', (req, res) => {
   eventController.getAllforUser(req, res)
   .then(events => {
     plainEvents = events.map(event => event.get({ plain: true }));
-    res.status(200).render('events', {events: plainEvents, logged_in: req.session.logged_in});
+    res.status(200).render('events', {
+      events: plainEvents,
+      logged_in: req.session.logged_in
+    });
   })
   .catch(err => {
       res.redirect('../');
@@ -19,11 +22,15 @@ router.get('/:id', (req, res) => {
   eventController.getOne(req, res)
   .then(event => {
     plainEvent = event.get({ plain: true });
-    res.status(200).render('eventprofile', {...event, logged_in: req.session.logged_in});
+    let ownsEvent = plainEvent.host_id == req.session.user_id;
+    res.status(200).render('eventprofile', {...plainEvent,
+      logged_in: req.session.logged_in,
+      ownsEvent
+    });
   })
   .catch(err => {
-      res.redirect('../');
-      console.log(err);
+    res.redirect('../');
+    console.log(err);
   })
 });
 

--- a/routes/viewRoutes/profileRoutes.js
+++ b/routes/viewRoutes/profileRoutes.js
@@ -30,42 +30,8 @@ router.get('/', withAuth, async (req, res) => {
 }
 );
 
-router.get('/event/:id', withAuth, async (req, res) => {
-    try {
-        // Find the user's dog based on the request parameter called dog_id
-        const event = await Event.findOne({
-            where: {id: req.params.id},
-            include: [{
-                model: Owner,
-                as: 'host',
-                attributes: ['first_name', 'last_name', 'pic_hyperlink'],
-                include: { model: Dog }
-              }, 
-              {
-                model: Owner,
-                as: 'attendees',
-                attributes: ['first_name','last_name', 'pic_hyperlink']
-              }, {
-                model: Comment,
-                attributes: ['text'],
-                include: { model: Owner, attributes: ['first_name'] }
-              }]
-          });
-        let eventObj = event.get({ plain: true });
-        if (req.session.user_id !== event.host_id) {
-            res.redirect('/profile');
-        };
-        res.render('eventprofile', {
-            ...eventObj,
-            logged_in: req.session.logged_in
-        });
-    } catch (err) {
-        res.redirect('/profile');
-    }
-})
-
 //Gets ALL posts and displays it on homepage
-router.get("/dog/:id", async (req, res) => {
+router.get('/dog/:id', async (req, res) => {
     // Send the rendered Handlebars.js template back as the response
     try {
         // Find the user's dog based on the request parameter called dog_id
@@ -85,7 +51,7 @@ router.get("/dog/:id", async (req, res) => {
 );
 
 //Gets ALL posts and displays it on homepage
-router.get("/owner/:id", withAuth, async (req, res) => {
+router.get('/owner/:id', withAuth, async (req, res) => {
     // Send the rendered Handlebars.js template back as the response
     try {
         // Find the logged in user based on the session ID

--- a/views/eventprofile.handlebars
+++ b/views/eventprofile.handlebars
@@ -1,4 +1,5 @@
-{{!-- EDIT EVENTS --}}
+{{!-- PAGE FOR VIEWING A SINGLE EVENT
+If owned by user, allow edit; otherwise, view public info --}}
 
 <div class="d-flex flex-row justify-content-center p-3">
     <div class="card event-{{id}}-card p-3">
@@ -18,7 +19,7 @@
     </div>
 </div>
 
-
+{{#if ownsEvent}}
 {{>uploadEvent}}
 
 {{!-- Edit Event Card --}}
@@ -70,5 +71,6 @@
 
     </div>
 </div>
+{{/if}}
 
 <script src="/js/edit-event.js"></script>

--- a/views/partials/eventcard.handlebars
+++ b/views/partials/eventcard.handlebars
@@ -12,8 +12,8 @@
                 <p class="event-description card-text">{{event.description}}</p>
 
                 <div class="buttons event-buttons flex-row justify-content-between">
-                    <a class="event-anchor" style="text-decoration: none" href="profile/event/{{event.id}}">
-                        <button class="edit-event-btn edit-event-btn btn-sm btn-danger"> Edit </button>
+                    <a class="event-anchor" style="text-decoration: none" href="events/{{event.id}}">
+                        <button class="edit-event-btn edit-event-btn btn-sm btn-danger"> View Details </button>
                     </a>
                     <button>
                         <img id="delete-event-btn" class="delete-event" data-id="{{event.id}}"


### PR DESCRIPTION
Changed 'edit' to 'view details' on event card.

Added conditional check to only show edit event form is user owns event. Removed /profile/event/:id route and replaced with /events/:id

All event cards and routes are now valid for all users, so we can view public info (like comments, time, place, etc), but conditionally allow edit.